### PR TITLE
【Fixed】デフォルトで helper と assets ファイルが生成されないようにconfig設定変更

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -2,22 +2,19 @@ require_relative 'boot'
 
 require 'rails/all'
 
-# Require the gems listed in Gemfile, including any gems
-# you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
 module CloneTw
   class Application < Rails::Application
-    # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
-    # Settings in config/environments/* take precedence over those specified here.
-    # Application configuration can go into files in config/initializers
-    # -- all .rb files in that directory are automatically loaded after loading
-    # the framework and any gems in your application.
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja 
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    
+    config.generators do |g|
+      g.assets     false
+      g.helper     false
+    end
   end
 end


### PR DESCRIPTION
#1
'rails g'コマンド実行時に自動的にhelper,assetsファイルが生成されないように、application.rbファイルの設定を変更　config.generators |g.assets g.helper|をfalseに設定。